### PR TITLE
fud2 support for FIRRTL

### DIFF
--- a/fud2/data/primitives-for-firrtl.sv
+++ b/fud2/data/primitives-for-firrtl.sv
@@ -1,0 +1,112 @@
+module std_mem_d1 #(
+    parameter WIDTH = 32,
+    parameter SIZE = 16,
+    parameter IDX_SIZE = 4
+) (
+   input wire                logic [IDX_SIZE-1:0] addr0,
+   input wire                logic [ WIDTH-1:0] write_data,
+   input wire                logic write_en,
+   input wire                logic clk,
+   input wire                logic reset,
+   output logic [ WIDTH-1:0] read_data,
+   output logic              done
+);
+
+   logic [WIDTH-1:0]         mem[SIZE-1:0];
+
+   initial begin
+      // CODE = $value$plusargs("DATA=%s", DATA);
+      // $display("DATA (path to meminit files): %s", DATA);
+      $readmemh({"sim_data/mem.dat"}, mem);
+   end
+   final begin
+      $writememh({"sim_data/mem.out"}, mem);
+   end
+
+  /* verilator lint_off WIDTH */
+  assign read_data = mem[addr0];
+
+  always_ff @(posedge clk) begin
+    if (reset)
+      done <= '0;
+    else if (write_en)
+      done <= '1;
+    else
+      done <= '0;
+  end
+
+  always_ff @(posedge clk) begin
+    if (!reset && write_en)
+      mem[addr0] <= write_data;
+  end
+
+  // Check for out of bounds access
+  `ifdef VERILATOR
+    always_comb begin
+      if (addr0 >= SIZE)
+        $error(
+          "std_mem_d1: Out of bounds access\n",
+          "addr0: %0d\n", addr0,
+          "SIZE: %0d", SIZE
+        );
+    end
+  `endif
+endmodule
+
+module std_wire #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] in,
+   output logic [WIDTH-1:0] out
+);
+assign out = in;
+endmodule
+
+module std_add #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] left,
+   input logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+assign out = left + right;
+endmodule
+
+module std_reg #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] in,
+   input logic write_en,
+   input logic clk,
+   input logic reset,
+   output logic [WIDTH-1:0] out,
+   output logic done
+);
+always_ff @(posedge clk) begin
+    if (reset) begin
+       out <= 0;
+       done <= 0;
+    end else if (write_en) begin
+      out <= in;
+      done <= 1'd1;
+    end else done <= 1'd0;
+  end
+endmodule
+
+module undef #(
+    parameter WIDTH = 32
+) (
+   output logic [WIDTH-1:0] out
+);
+assign out = 'x;
+endmodule
+
+module std_lt #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left < right;
+endmodule

--- a/fud2/data/primitives-for-firrtl.sv
+++ b/fud2/data/primitives-for-firrtl.sv
@@ -15,8 +15,6 @@ module std_mem_d1 #(
    logic [WIDTH-1:0]         mem[SIZE-1:0];
 
    initial begin
-      // CODE = $value$plusargs("DATA=%s", DATA);
-      // $display("DATA (path to meminit files): %s", DATA);
       $readmemh({"sim_data/mem.dat"}, mem);
    end
    final begin
@@ -51,6 +49,244 @@ module std_mem_d1 #(
         );
     end
   `endif
+endmodule
+
+/**
+ * Core primitives for Calyx.
+ * Implements core primitives used by the compiler.
+ *
+ * Conventions:
+ * - All parameter names must be SNAKE_CASE and all caps.
+ * - Port names must be snake_case, no caps.
+ */
+`default_nettype none
+
+module std_slice #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire                   logic [ IN_WIDTH-1:0] in,
+   output logic [OUT_WIDTH-1:0] out
+);
+  assign out = in[OUT_WIDTH-1:0];
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH < OUT_WIDTH)
+        $error(
+          "std_slice: Input width less than output width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_pad #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire logic [IN_WIDTH-1:0]  in,
+   output logic     [OUT_WIDTH-1:0] out
+);
+  localparam EXTEND = OUT_WIDTH - IN_WIDTH;
+  assign out = { {EXTEND {1'b0}}, in};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH > OUT_WIDTH)
+        $error(
+          "std_pad: Output width less than input width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_not #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] in,
+   output logic [WIDTH-1:0] out
+);
+  assign out = ~in;
+endmodule
+
+module std_and #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left & right;
+endmodule
+
+module std_or #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left | right;
+endmodule
+
+module std_xor #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left ^ right;
+endmodule
+
+module std_sub #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left - right;
+endmodule
+
+module std_gt #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left > right;
+endmodule
+
+module std_lt #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left < right;
+endmodule
+
+module std_eq #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left == right;
+endmodule
+
+module std_neq #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left != right;
+endmodule
+
+module std_ge #(
+    parameter WIDTH = 32
+) (
+    input wire   logic [WIDTH-1:0] left,
+    input wire   logic [WIDTH-1:0] right,
+    output logic out
+);
+  assign out = left >= right;
+endmodule
+
+module std_le #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left <= right;
+endmodule
+
+module std_lsh #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left << right;
+endmodule
+
+module std_rsh #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left >> right;
+endmodule
+
+/// this primitive is intended to be used
+/// for lowering purposes (not in source programs)
+module std_mux #(
+    parameter WIDTH = 32
+) (
+   input wire               logic cond,
+   input wire               logic [WIDTH-1:0] tru,
+   input wire               logic [WIDTH-1:0] fal,
+   output logic [WIDTH-1:0] out
+);
+  assign out = cond ? tru : fal;
+endmodule
+
+`default_nettype wire
+
+module undef #(
+    parameter WIDTH = 32
+) (
+   output logic [WIDTH-1:0] out
+);
+assign out = 'x;
+endmodule
+
+module std_const #(
+    parameter WIDTH = 32,
+    parameter VALUE = 32
+) (
+   output logic [WIDTH-1:0] out
+);
+assign out = VALUE;
 endmodule
 
 module std_wire #(
@@ -91,22 +327,4 @@ always_ff @(posedge clk) begin
       done <= 1'd1;
     end else done <= 1'd0;
   end
-endmodule
-
-module undef #(
-    parameter WIDTH = 32
-) (
-   output logic [WIDTH-1:0] out
-);
-assign out = 'x;
-endmodule
-
-module std_lt #(
-    parameter WIDTH = 32
-) (
-   input wire   logic [WIDTH-1:0] left,
-   input wire   logic [WIDTH-1:0] right,
-   output logic out
-);
-  assign out = left < right;
 endmodule

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -186,7 +186,7 @@ fn build_driver() -> Driver {
         &[calyx_setup, firrtl_verilog_setup],
         calyx,
         verilog,
-        |e, input, output| emit_verilog_via_firrtl(e, input, output),
+        emit_verilog_via_firrtl,
     );
 
     // Run the whole Calyx --> FIRRTL --> System-Verilog --> Execution via Icarus-Verilog pipeline

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -31,6 +31,20 @@ fn build_driver() -> Driver {
         },
     );
 
+    // Calyx-FIRRTL (move elsewhere)
+    let firrtl = bld.state("firrtl", &["fir"]);
+    bld.op(
+        "calyx-to-firrtl",
+        &[calyx_setup],
+        calyx,
+        firrtl,
+        |e, input, output| {
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "firrtl")?;
+            Ok(())
+        },
+    );
+
     // Dahlia.
     let dahlia = bld.state("dahlia", &["fuse"]);
     let dahlia_setup = bld.setup("Dahlia compiler", |e| {


### PR DESCRIPTION
Edit: I also added support for running the generated System-Verilog via Verilator!

This is a first pass at supporting the Calyx-FIRRTL backend in fud2! As a point of note, we can remove the `$extra_primitives` argument and the `primitives-for-firrtl.sv` file once I support primitives in FIRRTL.

Please let me know if there's anything I can improve/should fix here! I also included Setup and Usage notes below, but I can put them elsewhere as needed.

### Setup
To generate and run System-Verilog from Calyx-translated FIRRTL, we need the FIRRTL compiler. `<ROOT>` is the full path to the parent directory of where your repos live (most likely the parent directory of `fake` and `calyx`?).
Verilator, yosys, and sbt are also needed.
```
cd <ROOT>
git clone git@github.com:chipsalliance/firrtl.git
(
                cd firrtl
                sbt compile
                sbt test
                sbt assembly
) 
```

Then, edit the configuration file (`~/.config/fud2.toml`) to include the below:
```
[firrtl]
exe = "<ROOT>/firrtl/utils/bin/firrtl"
```

### Usage
In the below pseudo-commands, `<IN_FILE>` is the input Calyx file, and `<DATA_FILE>` is the JSON file containing data.

To generate FIRRTL from Calyx:
```
fud2 <IN_FILE> --to firrtl
```

To generate System-Verilog from Calyx-translated FIRRTL:
```
fud2 <IN_FILE> --to verilog --through firrtl
```

To run System-Verilog from Calyx-translated FIRRTL using Icarus-Verilog:
```
fud2 <IN_FILE> --to dat --through icarus-firrtl -s sim.data=<DATA_FILE>
```

To run System-Verilog from Calyx-translated FIRRTL using Verilator:
```
fud2 <IN_FILE> --to dat --through verilator-firrtl -s sim.data=<DATA_FILE>
```