### PR TITLE
Support for `primitive-uses` backend

### DIFF
--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -185,12 +185,12 @@ fn build_driver() -> Driver {
     );
 
     // primitive-uses backend
-    let json = bld.state("json", &["json"]);
+    let primitive_uses_json = bld.state("primitive-uses-json", &["json"]);
     bld.op(
         "primitive-uses",
         &[calyx_setup],
         calyx,
-        json,
+        primitive_uses_json,
         |e, input, output| {
             e.build_cmd(&[output], "calyx", &[input], &[])?;
             e.arg("backend", "primitive-uses")?;

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -184,16 +184,16 @@ fn build_driver() -> Driver {
         firrtl_compile,
     );
 
-    // primitive-inst backend (FIXME: rename)
+    // primitive-uses backend
     let json = bld.state("json", &["json"]);
     bld.op(
-        "primitive-instantiations",
+        "primitive-uses",
         &[calyx_setup],
         calyx,
         json,
         |e, input, output| {
             e.build_cmd(&[output], "calyx", &[input], &[])?;
-            e.arg("backend", "primitive-inst")?;
+            e.arg("backend", "primitive-uses")?;
             Ok(())
         },
     );

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -184,6 +184,20 @@ fn build_driver() -> Driver {
         firrtl_compile,
     );
 
+    // primitive-inst backend (FIXME: rename)
+    let json = bld.state("json", &["json"]);
+    bld.op(
+        "primitive-instantiations",
+        &[calyx_setup],
+        calyx,
+        json,
+        |e, input, output| {
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "primitive-inst")?;
+            Ok(())
+        },
+    );
+
     // Verilator.
     let verilator_setup = bld.setup("Verilator", |e| {
         e.config_var_or("verilator", "verilator.exe", "verilator")?;


### PR DESCRIPTION
This is a small PR adding support for the `primitive-uses` backend that lists all of the unique usages of primitives in a Calyx program!

Once I merge the [recent Calyx PR](https://github.com/calyxir/calyx/pull/1860), the `primitive-uses` backend can be used by running `fud2` with `--to primitive-uses-json`.

The next PR will consist of having fud2 automate the below process:
1. generating FIRRTL via the `firrtl` backend
2. getting info about primitive uses via the `primitive-uses` backend
3. running a Python script (currently sitting in the `generate-firrtl-mods` branch in the Calyx repo) that generates FIRRTL primitive code
4. putting the FIRRTL from (1) and (3) together